### PR TITLE
Fix custom image doesn't show issue

### DIFF
--- a/lib/src/alert.dart
+++ b/lib/src/alert.dart
@@ -247,7 +247,9 @@ class Alert {
 
   /// Returns alert image for icon
   Widget _getImage() {
-    Widget response = image ?? Container();
+    if (image != null) return image!;
+
+    Widget response = Container();
     switch (type) {
       case AlertType.success:
         response = Image.asset(
@@ -275,7 +277,6 @@ class Alert {
         break;
       case AlertType.none:
       default:
-        response = Container();
         break;
     }
     return response;


### PR DESCRIPTION
The custom image was overriding even it's not null in `_getImage()`.

fix issue https://github.com/RatelHub/rflutter_alert/issues/96 https://github.com/RatelHub/rflutter_alert/issues/108