### PR TITLE
Fixed image not displayed and now user can can even add his own images for different type of alerts

### DIFF
--- a/lib/src/alert.dart
+++ b/lib/src/alert.dart
@@ -275,9 +275,10 @@ class Alert {
         break;
       case AlertType.none:
       default:
-        response = Container();
+        response = image ?? Container();
         break;
     }
+    response = image ?? response;
     return response;
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -92,7 +92,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -127,7 +127,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
1). The bug related to displaying the image has been fixed.
2). Users can add costume images to an existing alert type.