### PR TITLE
Fixed the white padding on top if desc is null

### DIFF
--- a/lib/src/alert.dart
+++ b/lib/src/alert.dart
@@ -130,7 +130,7 @@ class Alert {
                                     textAlign: style.titleTextAlign,
                                   ),
                             SizedBox(
-                              height: desc == null ? 5 : 10,
+                              height: desc == null ? 0 : 10,
                             ),
                             desc == null
                                 ? Container()


### PR DESCRIPTION
For creating an alert with a gradient
Using Container to fill the whole alert with 0 padding

Before this change:
![before](https://user-images.githubusercontent.com/62955947/142156024-30e3a399-02b6-4560-abaf-df56a458ddb2.jpg)

After this change
![after](https://user-images.githubusercontent.com/62955947/142156017-9b26ae8b-4730-41f8-8682-f4808ea11e80.jpg)


Code to reproduce this alert:
```
final width = MediaQuery.of(context).size.width;
final height = MediaQuery.of(context).size.height;

Alert(
      context: context,
      type: AlertType.none,
      style: AlertStyle(
        buttonAreaPadding: EdgeInsets.zero,
        isCloseButton: false,
        isButtonVisible: false,
        alertBorder: RoundedRectangleBorder(
          borderRadius: BorderRadius.circular(0.0),
          side: BorderSide(
            color: Colors.grey,
          ),
        ),
        alertPadding:
            EdgeInsets.symmetric(horizontal: 20 / 375 * width, vertical: 0),
        constraints: BoxConstraints(
          minHeight: 0.6 * height,
          minWidth: 0.9 * width,
        ),
      ),
      padding: EdgeInsets.zero,
      content: Container(
        color: Colors.red,
        height: 0.6 * height,
        width: 0.95 * width,
        child: Column(
          children: <Widget>[],
        ),
      ),
      buttons: [],
    ).show();
```
